### PR TITLE
loadController() added

### DIFF
--- a/lib/CoreShop/Tool.php
+++ b/lib/CoreShop/Tool.php
@@ -105,6 +105,16 @@ class Tool {
     }
 
     /**
+     * Load Controller from CoreShop
+     * @param string $controllerName
+     */
+    public static function loadController( $controllerName = '' )
+    {
+        if( file_exists( CORESHOP_PATH . "/controllers/" . $controllerName . "Controller.php" ) )
+            require( CORESHOP_PATH . "/controllers/" . $controllerName . "Controller.php" );
+    }
+
+    /**
      * Format Tax
      *
      * TODO: Localization


### PR DESCRIPTION
use it to extend coreshop controller in your theme: `\CoreShop\Tool::loadController('Cart');`